### PR TITLE
Use mruby-tiny-io in favor of mruby-io

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,7 +1,7 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-  conf.gem :github => 'iij/mruby-io'
+  conf.gem :github => 'mimaki/mruby-tiny-io'
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-http'
   conf.gem '../mruby-simplehttpserver'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,7 +2,10 @@ MRuby::Gem::Specification.new('mruby-simplehttpserver') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.version = '0.0.1'
+
+  spec.add_dependency('mruby-string-ext')
   spec.add_dependency('mruby-tiny-io')
   spec.add_dependency('mruby-socket')
   spec.add_dependency('mruby-http')
+  spec.add_dependency('mruby-time')
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,7 +2,7 @@ MRuby::Gem::Specification.new('mruby-simplehttpserver') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.version = '0.0.1'
-  spec.add_dependency('mruby-io')
+  spec.add_dependency('mruby-tiny-io')
   spec.add_dependency('mruby-socket')
   spec.add_dependency('mruby-http')
 end

--- a/mrblib/mrb_simplehttpserver.rb
+++ b/mrblib/mrb_simplehttpserver.rb
@@ -153,7 +153,7 @@ class SimpleHttpServer
       # TODO: Add last-modified header, need File.mtime but not implemented
       @response_body = fp.read
       response = create_response
-    rescue File::FileError
+    rescue IOError
       set_response_headers "Content-Type" => nil
       @response_body = "Not Found on this server: #{r.path}\n"
       response = create_response 404


### PR DESCRIPTION
As the server only requires IO capabilities to read files, the much slimmer mruby-tiny-io might be a good alternative.