### PR TITLE
Set content type by file extension

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,7 +1,7 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-  conf.gem :github => 'mimaki/mruby-tiny-io'
+  conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-http'
   conf.gem '../mruby-simplehttpserver'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,8 +4,8 @@ MRuby::Gem::Specification.new('mruby-simplehttpserver') do |spec|
   spec.version = '0.0.1'
 
   spec.add_dependency('mruby-string-ext')
-  spec.add_dependency('mruby-tiny-io')
   spec.add_dependency('mruby-socket')
   spec.add_dependency('mruby-http')
   spec.add_dependency('mruby-time')
+  spec.add_dependency('mruby-io')
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,9 +3,9 @@ MRuby::Gem::Specification.new('mruby-simplehttpserver') do |spec|
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.version = '0.0.1'
 
-  spec.add_dependency('mruby-string-ext')
+  spec.add_dependency('mruby-string-ext', core: 'mruby-string-ext')
+  spec.add_dependency('mruby-time', core: 'mruby-time')
   spec.add_dependency('mruby-socket')
   spec.add_dependency('mruby-http')
-  spec.add_dependency('mruby-time')
   spec.add_dependency('mruby-io')
 end

--- a/mrblib/mrb_simplehttpserver.rb
+++ b/mrblib/mrb_simplehttpserver.rb
@@ -145,15 +145,28 @@ class SimpleHttpServer
     "#{tp[0]}, #{tp[2]} #{tp[1]} #{tp[5]} #{tp[3]} GMT"
   end
 
+  def content_type filename
+    ext = filename.split('.')[-1]
+
+    case ext
+    when 'txt', 'html', 'css'
+      "text/#{ext}; charset=utf-8"
+    when 'js'
+      'text/javascript; charset=utf-8'
+    else
+      'application/octet-stream; charset=utf-8'
+    end
+  end
+
   def file_response r, filename
     response = ""
     begin
       fp = File.open filename
-      set_response_headers "Content-Type" => "text/html; charset=utf-8"
+      set_response_headers "Content-Type" => content_type(filename)
       # TODO: Add last-modified header, need File.mtime but not implemented
       @response_body = fp.read
       response = create_response
-    rescue IOError
+    rescue File::FileError
       set_response_headers "Content-Type" => nil
       @response_body = "Not Found on this server: #{r.path}\n"
       response = create_response 404

--- a/mrblib/mrb_simplehttpserver.rb
+++ b/mrblib/mrb_simplehttpserver.rb
@@ -153,6 +153,10 @@ class SimpleHttpServer
       "text/#{ext}; charset=utf-8"
     when 'js'
       'text/javascript; charset=utf-8'
+    when 'gif', 'jpeg', 'png', 'tiff'
+      "image/#{ext}; charset=utf-8"
+    when 'json', 'xml'
+      "application/#{ext}; charset=utf-8"
     else
       'application/octet-stream; charset=utf-8'
     end


### PR DESCRIPTION
### About
1. Revert back to mruby-io:
    - mruby-socket depends on murby-io
2. Set content type by file extension

    ```ruby
    def content_type filename
      ext = filename.split('.')[-1]

      case ext
      when 'txt', 'html', 'css'
        "text/#{ext}; charset=utf-8"
      when 'js'
        'text/javascript; charset=utf-8'
      else
        'application/octet-stream; charset=utf-8'
      end
    end
    ```