### PR TITLE
Open file with correct mode

### DIFF
--- a/mrblib/mrb_simplehttpserver.rb
+++ b/mrblib/mrb_simplehttpserver.rb
@@ -173,7 +173,7 @@ class SimpleHttpServer
   def file_response r, filename
     response = ""
     begin
-      fp = File.open filename
+      fp = File.open filename, 'rb'
       set_response_headers "Content-Type" => content_type(filename)
       # TODO: Add last-modified header, need File.mtime but not implemented
       @response_body = fp.read

--- a/mrblib/mrb_simplehttpserver.rb
+++ b/mrblib/mrb_simplehttpserver.rb
@@ -151,14 +151,22 @@ class SimpleHttpServer
     case ext
     when 'txt', 'html', 'css'
       "text/#{ext}; charset=utf-8"
-    when 'js'
-      'text/javascript; charset=utf-8'
-    when 'gif', 'jpeg', 'png', 'tiff'
-      "image/#{ext}; charset=utf-8"
-    when 'json', 'xml'
+    when 'js', 'json', 'xml'
       "application/#{ext}; charset=utf-8"
+    when 'gif', 'jpeg', 'png', 'tiff'
+      "image/#{ext}"
+    when 'svg'
+      'image/svg+xml'
+    when 'otf', 'ttf'
+      'application/font-sfnt'
+    when 'eot'
+      'application/vnd.ms-fontobject'
+    when 'woff'
+      'application/font-woff'
+    when 'woff2'
+      'font/woff2'
     else
-      'application/octet-stream; charset=utf-8'
+      'application/octet-stream'
     end
   end
 


### PR DESCRIPTION
### About
1. Added more mime types:
    - fonts
    - images
2. Open files with correct mode `rb`.
    - The default mode `r` doesn't work for binary files like fonts.