### PR TITLE
Not include method name in HTTP response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ compiler:
 
 env:
 - MRUBY_VERSION=1.3.0
-- MRUBY_VERSION=1.4.0
+- MRUBY_VERSION=1.4.1
 - MRUBY_VERSION=head
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ compiler:
 - clang
 
 env:
-- MRUBY_VERSION=1.3.0
 - MRUBY_VERSION=1.4.1
 - MRUBY_VERSION=head
 

--- a/test/mrb_simplehttpserver.rb
+++ b/test/mrb_simplehttpserver.rb
@@ -68,7 +68,6 @@ assert 'SimpleHttpServer#run' do
 
     res = `curl -si localhost:8000/mruby`
     h.parse_response(res) {|x|
-      assert_equal 'GET', x.method
       assert_equal 'mruby-simplehttpserver', x.headers['Server']
       assert_nil x.headers['Content-type']
       assert_equal "Hello mruby World.\n", x.body


### PR DESCRIPTION
Unlike HTTP request, HTTP response generally doesn't include the HTTP method name for corresponding to the request you send.