### PR TITLE
Use StringIO as SHELF_INPUT

### DIFF
--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -7,30 +7,35 @@ builds:
     https://github.com/mattn/mruby-http.git:
       url: https://github.com/mattn/mruby-http.git
       branch: HEAD
-      commit: dfabda4dc0fa8581a8760097c0cb79d4395199a5
+      commit: 003c2af0a059c50a3546001860108ff4bf3a2cac
       version: 0.0.0
     https://github.com/katzer/mruby-shelf.git:
       url: https://github.com/katzer/mruby-shelf.git
       branch: HEAD
-      commit: fe72d925b71576cfd05aed35829759c67988a068
+      commit: 3bf2bc69eaceb4555ded37081e61c247808e6d88
       version: 0.0.0
-    https://github.com/appPlant/mruby-process.git:
-      url: https://github.com/appPlant/mruby-process.git
+    https://github.com/ksss/mruby-stringio.git:
+      url: https://github.com/ksss/mruby-stringio.git
       branch: HEAD
-      commit: d9e4913005958950ced5505238ba71c28d10f3a4
+      commit: 97cc4434519e85a0785a1b4cf6f872a220f772db
+      version: 0.0.0
+    https://github.com/katzer/mruby-process.git:
+      url: https://github.com/katzer/mruby-process.git
+      branch: HEAD
+      commit: 03a4f8110b4d32b5ff56f78560c255e80dcf9219
       version: 0.0.0
     https://github.com/katzer/mruby-r3.git:
       url: https://github.com/katzer/mruby-r3.git
       branch: HEAD
-      commit: 185455010e82fdc491ded1c705b2c0521bb266ba
+      commit: c5b5ae647a8f04a86b4cd519273ba243bd459aec
       version: 0.0.0
     https://github.com/iij/mruby-env.git:
       url: https://github.com/iij/mruby-env.git
       branch: HEAD
       commit: 056ae324451ef16a50c7887e117f0ea30921b71b
       version: 0.0.0
-    https://github.com/appPlant/mruby-os.git:
-      url: https://github.com/appPlant/mruby-os.git
+    https://github.com/katzer/mruby-os.git:
+      url: https://github.com/katzer/mruby-os.git
       branch: HEAD
-      commit: 89523f3a2a4e800c394165695e12b3d92d5775a1
+      commit: 8e6e1dca8284f142bea681bfe032ebe7bae3851a
       version: 0.0.0

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -30,6 +30,7 @@ MRuby::Gem::Specification.new('mruby-simplehttpserver') do |spec|
   spec.add_dependency('mruby-time', core: 'mruby-time')
   spec.add_dependency('mruby-http')
   spec.add_dependency('mruby-shelf')
+  spec.add_dependency('mruby-stringio')
 
   if MRuby::Source::MRUBY_VERSION >= '1.4.0'
     spec.add_dependency('mruby-io', core: 'mruby-io')

--- a/test/mrb_simplehttpserver.rb
+++ b/test/mrb_simplehttpserver.rb
@@ -18,6 +18,8 @@ app = Proc.new do |env|
   when '/html'
     headers['Content-type'] = 'text/html; charset=utf-8'
     body = '<H1>Hello mruby World.</H1>'
+  when '/echo'
+    body = env['shelf.input'].read
   when '/notfound'
     # Custom error response message
     body = "Not Found on this server: #{path}"
@@ -77,6 +79,11 @@ assert 'SimpleHttpServer#run' do
     h.parse_response(res) {|x|
       assert_equal 'text/html; charset=utf-8', x.headers['Content-type']
       assert_equal "<H1>Hello mruby World.</H1>", x.body
+    }
+
+    res = `curl -si localhost:8000/echo -d 'This is body'`
+    h.parse_response(res) {|x|
+      assert_equal "This is body", x.body
     }
 
     res = `curl -si localhost:8000/notfound`


### PR DESCRIPTION
Closes https://github.com/matsumotory/mruby-simplehttpserver/issues/31

## problem

It seemed that `env[Shelf::SHELF_INPUT]` does not work, because `io` is completely consumed.
So we can never read the HTTP request body in the current SimpleHttpServer implementation.
If we try to do `env[Shelf::SHELF_INPUT].read`, it blocks forever (the added test never finishes).

## solution

So I replaced `env[Shelf::SHELF_INPUT]` with `StringIO` which holds `request.body` as content.
By this PR, we are able to read request body like: `env[Shelf::SHELF_INPUT].read #=> "request body"`

## note

I re-generated `build_config.rb.lock` in order to run `rake test`.
When I run the test without it, the following error is raised:

```shell-session
$ rake test
GIT CHECKOUT DETACH /Users/sangenya/dev/mruby-simplehttpserver/mruby/build/repos/host/mruby-http -> dfabda4dc0fa8581a8760097c0cb79d4395199a5
fatal: reference is not a tree: dfabda4dc0fa8581a8760097c0cb79d4395199a5
fatal: reference is not a tree: dfabda4dc0fa8581a8760097c0cb79d4395199a5
....
```

Though I could not figure out why this occurs...